### PR TITLE
Fix #108 For KB concepts the given "valueName" of statements should be the english label instead of the wikipedia page title

### DIFF
--- a/src/main/java/com/scienceminer/nerd/kb/Concept.java
+++ b/src/main/java/com/scienceminer/nerd/kb/Concept.java
@@ -1,16 +1,12 @@
 package com.scienceminer.nerd.kb;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-import java.util.ArrayList;
-
+import com.scienceminer.nerd.kb.db.KBUpperEnvironment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.scienceminer.nerd.kb.db.*;
-import com.scienceminer.nerd.kb.model.Page.PageType;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 /**
  * An language-independent atomic element of the (N)ERD Knowledge Base.
@@ -36,6 +32,14 @@ public class Concept {
 		return localMap.get(lang); 
 	}
 
+	public String getLabelByLang(String lang) {
+		// Hack : only the en label is supported for the moment
+		if (lang.equals("en")) {
+			Optional<Statement> enLabelSt = env.getDbStatements().retrieve(wikidataId).stream().filter(st -> st.getPropertyId().equals("P0")).findFirst();
+			return enLabelSt.isPresent() ? enLabelSt.get().getValue() : null;
+		}
+		return null;
+	}
 	/**
 	 * Return the list of statements associated to the concept
 	 */

--- a/src/main/java/com/scienceminer/nerd/kb/Statement.java
+++ b/src/main/java/com/scienceminer/nerd/kb/Statement.java
@@ -1,11 +1,8 @@
 package com.scienceminer.nerd.kb;
 
+import com.fasterxml.jackson.core.io.JsonStringEncoder;
+
 import java.io.Serializable;
-
-import com.scienceminer.nerd.kb.db.*;
-import com.scienceminer.nerd.kb.model.*;
-
-import com.fasterxml.jackson.core.io.*;
 
 /**
  * Class for representing and exchanging a semantic statement about an entity.
@@ -125,33 +122,27 @@ public class Statement implements Serializable {
                 Concept concept = null;
                 if (value.startsWith("Q")) {
                     sb.append(", \"value\" : \"" + value + "\"");
-                    concept = UpperKnowledgeBase.getInstance().getConcept(value);                    
+                    concept = UpperKnowledgeBase.getInstance().getConcept(value);
                 } else {
                     sb.append(", \"value\" : " + value);
                     concept = UpperKnowledgeBase.getInstance().getConcept(value.replace("\"", ""));
                 }
 
                 if (concept != null) {
-                    Integer pageId = concept.getPageIdByLang("en");
-                    if (pageId != null) {
-                        LowerKnowledgeBase wikipedia = UpperKnowledgeBase.getInstance().getWikipediaConf("en");
-                        Page page = wikipedia.getPageById(pageId);
-                        if (page != null) {
-                            byte[] encodedValueTitle = encoder.quoteAsUTF8(page.getTitle());
-                            String outputValueTitle = new String(encodedValueTitle); 
-                            sb.append(", \"valueName\" : \"" + outputValueTitle + "\"");
+                    // Hack : use en label instead of title page if exists for valueName
+                    String enLabel = concept.getLabelByLang("en");
+                    if (enLabel != null) {
+                            byte[] encodedValueLabel = encoder.quoteAsUTF8(enLabel);
+                            String outputValueLabel = new String(encodedValueLabel);
+                            sb.append(", \"valueName\" : \"" + outputValueLabel + "\"");
                             done = true;
                         }
-                    }
                 }
-                /*if (!done)
-                    sb.append(", \"value\" : \"" + value + "\"");*/  
+
             } else
                 sb.append(", \"value\" : " + value);   
         }
-
-        sb.append("}");   
-
+        sb.append("}");
         return sb.toString();
     }    
 }

--- a/src/main/java/com/scienceminer/nerd/kb/db/PropertyDatabase.java
+++ b/src/main/java/com/scienceminer/nerd/kb/db/PropertyDatabase.java
@@ -2,16 +2,12 @@ package com.scienceminer.nerd.kb.db;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
-import com.scienceminer.nerd.kb.Property;
 import com.scienceminer.nerd.exceptions.NerdResourceException;
-
+import com.scienceminer.nerd.kb.Property;
 import org.apache.commons.compress.compressors.CompressorInputStream;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.apache.hadoop.record.CsvRecordInput;
-
 import org.fusesource.lmdbjni.Transaction;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,7 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class PropertyDatabase extends StringRecordDatabase<Property> {
-	private static final Logger logger = LoggerFactory.getLogger(PropertyDatabase.class);	
+	private static final Logger logger = LoggerFactory.getLogger(PropertyDatabase.class);
 
 	public PropertyDatabase(KBEnvironment env) {
 		super(env, DatabaseType.properties);
@@ -52,6 +48,9 @@ public class PropertyDatabase extends StringRecordDatabase<Property> {
 		String line = null;
 		ObjectMapper mapper = new ObjectMapper();
 		List<Property> properties = new ArrayList<Property>();
+		// Hack : fake property to store the english label of every concept
+		// Should probably be TEXT if we want to support all labels and not only the en label
+		properties.add(new Property("P0", "label", Property.ValueType.STRING));
 		while ((line=reader.readLine()) != null) {
 			if (line.length() == 0) continue;
 			if (line.startsWith("[")) continue;


### PR DESCRIPTION
Hi Patrice
As you recommend for the moment the proposed modification is done in entity fishing (not in grisp) creating a fake property P0 / label as new statement